### PR TITLE
Closes #6 Improve error reporting based on user reproduction attempts

### DIFF
--- a/__bak3/BinomialCoefficient.js
+++ b/__bak3/BinomialCoefficient.js
@@ -1,0 +1,31 @@
+/*
+ * Author: Akshay Dubey (https://github.com/itsAkshayDubey)
+ * Binomial Coefficient: https://en.wikipedia.org/wiki/Binomial_coefficient
+ * function to find binomial coefficient of numbers n and k.
+ * return binomial coefficient of n,k
+ */
+
+/**
+ * @function findBinomialCoefficient
+ * @description -> this function returns binomial coefficient
+ * of two numbers n & k given by n!/((n-k)!k!)
+ * @param {number} n
+ * @param {number} k
+ * @returns {number}
+ */
+
+import { calcFactorial } from './Factorial'
+
+export const findBinomialCoefficient = (n, k) => {
+  if (typeof n !== 'number' || typeof k !== 'number') {
+    throw Error('Type of arguments must be number.')
+  }
+  if (n < 0 || k < 0) {
+    throw Error('Arguments must be greater than zero.')
+  }
+  let product = 1
+  for (let i = n; i > k; i--) {
+    product *= i
+  }
+  return product / calcFactorial(n - k)
+}

--- a/__bak3/GeofenceTests.cs
+++ b/__bak3/GeofenceTests.cs
@@ -1,0 +1,60 @@
+using Algorithms.Other;
+
+namespace Algorithms.Tests.Other
+{
+    [TestFixture]
+    public class GeofenceTests
+    {
+        private Geofence? geofence;
+
+        [SetUp]
+        public void Setup()
+        {
+            geofence = new Geofence(10.8231, 106.6297, 500);
+        }
+
+        [Test]
+        public void IsInside_ShouldReturnTrue_WhenUserIsInsideGeofence()
+        {
+            double userLat = 10.8221;
+            double userLon = 106.6289;
+
+            bool? result = geofence?.IsInside(userLat, userLon);
+
+            Assert.That(result, Is.True);
+        }
+
+        [Test]
+        public void IsInside_ShouldReturnFalse_WhenUserIsOutsideGeofence()
+        {
+            double userLat = 10.8300;
+            double userLon = 106.6400;
+
+            bool? result = geofence?.IsInside(userLat, userLon);
+
+            Assert.That(result, Is.False);
+        }
+
+        [Test]
+        public void IsInside_ShouldReturnTrue_WhenUserIsExactlyOnGeofenceBoundary()
+        {
+            double userLat = 10.8231;
+            double userLon = 106.6297;
+
+            bool? result = geofence?.IsInside(userLat, userLon);
+
+            Assert.That(result, Is.True);
+        }
+
+        [Test]
+        public void IsInside_ShouldReturnFalse_WhenUserIsFarFromGeofence()
+        {
+            double userLat = 20.0000;
+            double userLon = 100.0000;
+
+            bool? result = geofence?.IsInside(userLat, userLon);
+
+            Assert.That(result, Is.False);
+        }
+    }
+}

--- a/__bak3/RLE.test.js
+++ b/__bak3/RLE.test.js
@@ -1,0 +1,13 @@
+import { Compress, Decompress } from '../RLE'
+
+describe('Test RLE Compressor/Decompressor', () => {
+  it('Test - 1, Pass long repetitive strings', () => {
+    expect(Compress('AAAAAAAAAAAAAA')).toBe('14A')
+    expect(Compress('AAABBQQQQQFG')).toBe('3A2B5Q1F1G')
+  })
+
+  it('Test - 2, Pass compressed strings', () => {
+    expect(Decompress('14A')).toBe('AAAAAAAAAAAAAA')
+    expect(Decompress('3A2B5Q1F1G')).toBe('AAABBQQQQQFG')
+  })
+})

--- a/__bak3/UpperTest.java
+++ b/__bak3/UpperTest.java
@@ -1,0 +1,18 @@
+package com.thealgorithms.strings;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+public class UpperTest {
+
+    @Test
+    public void toUpperCase() {
+        String input1 = "hello world";
+        String input2 = "hElLo WoRlD";
+        String input3 = "HELLO WORLD";
+        assertEquals("HELLO WORLD", Upper.toUpperCase(input1));
+        assertEquals("HELLO WORLD", Upper.toUpperCase(input2));
+        assertEquals("HELLO WORLD", Upper.toUpperCase(input3));
+    }
+}

--- a/__bak3/euclidean_distance.r
+++ b/__bak3/euclidean_distance.r
@@ -1,0 +1,8 @@
+euclideanDistance <- function(x, y) {
+    return(sqrt(sum((x - y)^2)))
+}
+
+set.seed(1)
+x <- rnorm(1000)
+y <- runif(1000)
+print(euclideanDistance(x, y))

--- a/__bak3/perfect_square.test.ts
+++ b/__bak3/perfect_square.test.ts
@@ -1,0 +1,9 @@
+import { perfectSquare } from '../perfect_square'
+
+test('Check perfect square', () => {
+  expect(perfectSquare(16)).toBe(true)
+  expect(perfectSquare(12)).toBe(false)
+  expect(perfectSquare(19)).toBe(false)
+  expect(perfectSquare(25)).toBe(true)
+  expect(perfectSquare(42)).toBe(false)
+})


### PR DESCRIPTION
6 Refactored the error messages for missing environmental credentials to provide more granular feedback, such as identifying specifically which API key is missing. This replaces the generic 'Error 1' with actionable instructions for the user. Improved the logger's verbosity during the initial handshake.