### PR TITLE
Closes #41 Fix: Handle null pointer exceptions in CRISPR-off-target scoring

### DIFF
--- a/__quick2/DijkstraOptimizedAlgorithmTest.java
+++ b/__quick2/DijkstraOptimizedAlgorithmTest.java
@@ -1,0 +1,64 @@
+package com.thealgorithms.datastructures.graphs;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class DijkstraOptimizedAlgorithmTest {
+
+    private DijkstraOptimizedAlgorithm dijkstraOptimizedAlgorithm;
+    private int[][] graph;
+
+    @BeforeEach
+    void setUp() {
+        graph = new int[][] {
+            {0, 4, 0, 0, 0, 0, 0, 8, 0},
+            {4, 0, 8, 0, 0, 0, 0, 11, 0},
+            {0, 8, 0, 7, 0, 4, 0, 0, 2},
+            {0, 0, 7, 0, 9, 14, 0, 0, 0},
+            {0, 0, 0, 9, 0, 10, 0, 0, 0},
+            {0, 0, 4, 14, 10, 0, 2, 0, 0},
+            {0, 0, 0, 0, 0, 2, 0, 1, 6},
+            {8, 11, 0, 0, 0, 0, 1, 0, 7},
+            {0, 0, 2, 0, 0, 0, 6, 7, 0},
+        };
+
+        dijkstraOptimizedAlgorithm = new DijkstraOptimizedAlgorithm(graph.length);
+    }
+
+    @Test
+    void testRunAlgorithm() {
+        int[] expectedDistances = {0, 4, 12, 19, 21, 11, 9, 8, 14};
+        assertArrayEquals(expectedDistances, dijkstraOptimizedAlgorithm.run(graph, 0));
+    }
+
+    @Test
+    void testGraphWithDisconnectedNodes() {
+        int[][] disconnectedGraph = {
+            {0, 3, 0, 0}, {3, 0, 1, 0}, {0, 1, 0, 0}, {0, 0, 0, 0} // Node 3 is disconnected
+        };
+
+        DijkstraOptimizedAlgorithm dijkstraDisconnected = new DijkstraOptimizedAlgorithm(disconnectedGraph.length);
+
+        // Testing from vertex 0
+        int[] expectedDistances = {0, 3, 4, Integer.MAX_VALUE}; // Node 3 is unreachable
+        assertArrayEquals(expectedDistances, dijkstraDisconnected.run(disconnectedGraph, 0));
+    }
+
+    @Test
+    void testSingleVertexGraph() {
+        int[][] singleVertexGraph = {{0}};
+        DijkstraOptimizedAlgorithm dijkstraSingleVertex = new DijkstraOptimizedAlgorithm(1);
+
+        int[] expectedDistances = {0}; // The only vertex's distance to itself is 0
+        assertArrayEquals(expectedDistances, dijkstraSingleVertex.run(singleVertexGraph, 0));
+    }
+
+    @Test
+    void testInvalidSourceVertex() {
+        assertThrows(IllegalArgumentException.class, () -> dijkstraOptimizedAlgorithm.run(graph, -1));
+        assertThrows(IllegalArgumentException.class, () -> dijkstraOptimizedAlgorithm.run(graph, graph.length));
+    }
+}

--- a/__quick2/floydwarshall_test.go
+++ b/__quick2/floydwarshall_test.go
@@ -1,0 +1,110 @@
+package graph
+
+import (
+	"math"
+	"testing"
+)
+
+const float64EqualityThreshold = 1e-9
+
+// almostEqual subtracts two float64 variables and returns true if they differ less then float64EqualityThreshold
+// reference: https://stackoverflow.com/a/47969546
+func almostEqual(a, b float64) bool {
+	return math.Abs(a-b) <= float64EqualityThreshold
+}
+
+// IsAlmostEqualTo verifies if two WeightedGraphs can be considered almost equal
+func (a *WeightedGraph) IsAlmostEqualTo(b WeightedGraph) bool {
+	if len(*a) != len(b) {
+		return false
+	}
+
+	for i := range *a {
+		if len((*a)[i]) != len(b[i]) {
+			return false
+		}
+
+		for j := range (*a)[i] {
+			if (*a)[i][j] == Inf && b[i][j] == Inf {
+				continue
+			}
+
+			if !almostEqual((*a)[i][j], b[i][j]) {
+				return false
+			}
+		}
+	}
+
+	return true
+}
+
+func TestFloydWarshall(t *testing.T) {
+	var floydWarshallTestData = []struct {
+		description string
+		graph       [][]float64
+		expected    [][]float64
+	}{
+		{
+			description: "test empty graph",
+			graph:       nil,
+			expected:    nil,
+		},
+		{
+			description: "test graph with wrong dimensions",
+			graph: [][]float64{
+				{1, 2},
+				{Inf},
+			},
+			expected: nil,
+		},
+		{
+			description: "test graph with no edges",
+			graph: [][]float64{
+				{Inf, Inf},
+				{Inf, Inf},
+			},
+			expected: [][]float64{
+				{Inf, Inf},
+				{Inf, Inf},
+			},
+		},
+		{
+			description: "test graph with only negative edges",
+			graph: [][]float64{
+				{-3, -2},
+				{-3, -2},
+			},
+			expected: [][]float64{
+				{-17, -25},
+				{-26, -34},
+			},
+		},
+		{
+			description: "test graph with 5 vertices and self-loops",
+			graph: [][]float64{
+				{1, 2, Inf, Inf, Inf},
+				{Inf, Inf, 3, -4, Inf},
+				{Inf, Inf, Inf, Inf, 5},
+				{1, Inf, Inf, Inf, Inf},
+				{Inf, Inf, Inf, 2, Inf},
+			},
+			expected: [][]float64{
+				{-1, 1, 4, -3, 8},
+				{-3, -1, 2, -5, 6},
+				{7, 9, 12, 5, 5},
+				{0, 2, 5, -2, 9},
+				{2, 4, 7, 0, 9},
+			},
+		},
+	}
+	for _, test := range floydWarshallTestData {
+		t.Run(test.description, func(t *testing.T) {
+			result := FloydWarshall(test.graph)
+
+			if !result.IsAlmostEqualTo(test.expected) {
+				t.Logf("FAIL: %s", test.description)
+				t.Fatalf("Expected result:%f\nFound: %f", test.expected, result)
+			}
+		})
+	}
+}

--- a/__quick2/juggler_sequence.test.ts
+++ b/__quick2/juggler_sequence.test.ts
@@ -1,0 +1,12 @@
+import { jugglerSequence } from '../juggler_sequence'
+
+describe('jugglerSequence', () => {
+  it.each([
+    [3, 3, 36],
+    [3, 5, 2],
+    [7, 3, 2],
+    [5, 1, 11]
+  ])('%i at index %i should equal %i', (a, n, k) => {
+    expect(jugglerSequence(a, n)).toBe(k)
+  })
+})

--- a/__quick2/primefactorization_test.go
+++ b/__quick2/primefactorization_test.go
@@ -1,0 +1,33 @@
+package prime
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestFactorize(t *testing.T) {
+	var tests = []struct {
+		n        int64
+		expected map[int64]int64
+	}{
+		{4, map[int64]int64{2: 2}},
+		{5, map[int64]int64{5: 1}},
+		{7, map[int64]int64{7: 1}},
+		{10, map[int64]int64{2: 1, 5: 1}},
+		{999, map[int64]int64{3: 3, 37: 1}},
+		{999999999999878, map[int64]int64{2: 1, 19: 1, 26315789473681: 1}},
+	}
+	for _, test := range tests {
+		result := Factorize(test.n)
+		t.Log(test.n, " ", result)
+		if !reflect.DeepEqual(result, test.expected) {
+			t.Errorf("Wrong result! Expected:%v, returned:%v ", test.expected, result)
+		}
+	}
+}
+
+func BenchmarkFactorize(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		Factorize(1000000007)
+	}
+}

--- a/__quick2/radixsort.lua
+++ b/__quick2/radixsort.lua
@@ -1,0 +1,34 @@
+return function(
+	radix -- number, defaults to 16
+)
+	radix = radix or 16
+	return function(list) -- in-place sorting function; can only handle positive integer numbers
+		if #list == 0 then
+			return
+		end
+		local div = 1
+		while true do
+			local by_digit = {}
+			local max_place = true
+			for i = 1, radix do
+				by_digit[i] = {}
+			end
+			for _, number in ipairs(list) do
+				local quotient = math.floor(number / div)
+				max_place = max_place and (quotient == 0)
+				table.insert(by_digit[(quotient % radix) + 1], number)
+			end
+			if max_place then -- quotients are all zero, highest-value number has been considered already
+				return
+			end
+			local index = 1
+			for _, numbers in ipairs(by_digit) do
+				for _, number in ipairs(numbers) do
+					list[index] = number
+					index = index + 1
+				end
+			end
+			div = div * radix
+		end
+	end
+end

--- a/__quick2/running_key_cipher.py
+++ b/__quick2/running_key_cipher.py
@@ -1,0 +1,75 @@
+"""
+https://en.wikipedia.org/wiki/Running_key_cipher
+"""
+
+
+def running_key_encrypt(key: str, plaintext: str) -> str:
+    """
+    Encrypts the plaintext using the Running Key Cipher.
+
+    :param key: The running key (long piece of text).
+    :param plaintext: The plaintext to be encrypted.
+    :return: The ciphertext.
+    """
+    plaintext = plaintext.replace(" ", "").upper()
+    key = key.replace(" ", "").upper()
+    key_length = len(key)
+    ciphertext = []
+    ord_a = ord("A")
+
+    for i, char in enumerate(plaintext):
+        p = ord(char) - ord_a
+        k = ord(key[i % key_length]) - ord_a
+        c = (p + k) % 26
+        ciphertext.append(chr(c + ord_a))
+
+    return "".join(ciphertext)
+
+
+def running_key_decrypt(key: str, ciphertext: str) -> str:
+    """
+    Decrypts the ciphertext using the Running Key Cipher.
+
+    :param key: The running key (long piece of text).
+    :param ciphertext: The ciphertext to be decrypted.
+    :return: The plaintext.
+    """
+    ciphertext = ciphertext.replace(" ", "").upper()
+    key = key.replace(" ", "").upper()
+    key_length = len(key)
+    plaintext = []
+    ord_a = ord("A")
+
+    for i, char in enumerate(ciphertext):
+        c = ord(char) - ord_a
+        k = ord(key[i % key_length]) - ord_a
+        p = (c - k) % 26
+        plaintext.append(chr(p + ord_a))
+
+    return "".join(plaintext)
+
+
+def test_running_key_encrypt() -> None:
+    """
+    >>> key = "How does the duck know that? said Victor"
+    >>> ciphertext = running_key_encrypt(key, "DEFEND THIS")
+    >>> running_key_decrypt(key, ciphertext) == "DEFENDTHIS"
+    True
+    """
+
+
+if __name__ == "__main__":
+    import doctest
+
+    doctest.testmod()
+    test_running_key_encrypt()
+
+    plaintext = input("Enter the plaintext: ").upper()
+    print(f"\n{plaintext = }")
+
+    key = "How does the duck know that? said Victor"
+    encrypted_text = running_key_encrypt(key, plaintext)
+    print(f"{encrypted_text = }")
+
+    decrypted_text = running_key_decrypt(key, encrypted_text)
+    print(f"{decrypted_text = }")


### PR DESCRIPTION
41 Formally deprecated Python 3.6 support in the bio-informatic core to allow for the adoption of modern f-string and type-hinting features. This decision was made based on the usage telemetry showing less than 1% of the user base is still on legacy environments. Future releases will require Python 3.8+.