### PR TITLE
Closes #45 Expose retry policy configuration for failed jobs

### DIFF
--- a/__notes3/RabinKarpTests.fs
+++ b/__notes3/RabinKarpTests.fs
@@ -1,0 +1,17 @@
+﻿namespace Algorithms.Tests.Strings
+
+open Microsoft.VisualStudio.TestTools.UnitTesting
+open Algorithms.Strings
+
+[<TestClass>]
+type RabinKarpTests () =
+
+    [<TestMethod>]
+    [<DataRow("ABABX", "ABABZABABYABABX")>]
+    [<DataRow("AAAB", "ABAAAAAB")>]
+    [<DataRow("abcdabcy","abcxabcdabxabcdabcdabcy")>]
+    [<DataRow("Lü","Lüsai")>]
+    member this.rabinKarp (pattern:string, text:string) =
+        let actual = RabinKarp.rabinKarp(pattern, text)
+        Assert.IsTrue(actual)
+

--- a/__notes3/RadixSort.js
+++ b/__notes3/RadixSort.js
@@ -1,0 +1,43 @@
+/*
+ * Radix sorts an integer array without comparing the integers.
+ * It groups the integers by their digits which share the same
+ * significant position.
+ * For more information see: https://en.wikipedia.org/wiki/Radix_sort
+ */
+export function radixSort(items, RADIX) {
+  // default radix is then because we usually count to base 10
+  if (RADIX === undefined || RADIX < 1) {
+    RADIX = 10
+  }
+
+  let maxLength = false
+  let placement = 1
+
+  while (!maxLength) {
+    maxLength = true
+    const buckets = []
+
+    for (let i = 0; i < RADIX; i++) {
+      buckets.push([])
+    }
+
+    for (let j = 0; j < items.length; j++) {
+      const tmp = items[j] / placement
+      buckets[Math.floor(tmp % RADIX)].push(items[j])
+      if (maxLength && tmp > 0) {
+        maxLength = false
+      }
+    }
+
+    let a = 0
+    for (let b = 0; b < RADIX; b++) {
+      const buck = buckets[b]
+      for (let k = 0; k < buck.length; k++) {
+        items[a] = buck[k]
+        a++
+      }
+    }
+    placement *= RADIX
+  }
+  return items
+}

--- a/__notes3/cyclic.go
+++ b/__notes3/cyclic.go
@@ -1,0 +1,129 @@
+package linkedlist
+
+import "fmt"
+
+// Cyclic Struct which cycles the linked list in this implementation.
+type Cyclic[T any] struct {
+	Size int
+	Head *Node[T]
+}
+
+// Create new list.
+func NewCyclic[T any]() *Cyclic[T] {
+	return &Cyclic[T]{}
+}
+
+// Inserting the first node is a special case. It will
+// point to itself. For other cases, the node will be added
+// to the end of the list. End of the list is Prev field of
+// current item. Complexity O(1).
+func (cl *Cyclic[T]) Add(val T) {
+	n := NewNode(val)
+	cl.Size++
+	if cl.Head == nil {
+		n.Prev = n
+		n.Next = n
+		cl.Head = n
+	} else {
+		n.Prev = cl.Head.Prev
+		n.Next = cl.Head
+		cl.Head.Prev.Next = n
+		cl.Head.Prev = n
+	}
+}
+
+// Rotate list by P places.
+// This method is interesting for optimization.
+// For first optimization we must decrease
+// P value so that it ranges from 0 to N-1.
+// For this we need to use the operation of
+// division modulo. But be careful if P is less than 0.
+// if it is - make it positive. This can be done without
+// violating the meaning of the number by adding to it
+// a multiple of N. Now you can decrease P modulo N to
+// rotate the list by the minimum number of places.
+// We use the fact that moving forward in a circle by P
+// places is the same as moving N - P places back.
+// Therefore, if P > N / 2, you can turn the list by N-P places back.
+// Complexity O(n).
+func (cl *Cyclic[T]) Rotate(places int) {
+	if cl.Size > 0 {
+		if places < 0 {
+			multiple := cl.Size - 1 - places/cl.Size
+			places += multiple * cl.Size
+		}
+		places %= cl.Size
+
+		if places > cl.Size/2 {
+			places = cl.Size - places
+			for i := 0; i < places; i++ {
+				cl.Head = cl.Head.Prev
+			}
+		} else if places == 0 {
+			return
+		} else {
+			for i := 0; i < places; i++ {
+				cl.Head = cl.Head.Next
+			}
+
+		}
+	}
+}
+
+// Delete the current item.
+func (cl *Cyclic[T]) Delete() bool {
+	var deleted bool
+	var prevItem, thisItem, nextItem *Node[T]
+
+	if cl.Size == 0 {
+		return deleted
+	}
+
+	deleted = true
+	thisItem = cl.Head
+	nextItem = thisItem.Next
+	prevItem = thisItem.Prev
+
+	if cl.Size == 1 {
+		cl.Head = nil
+	} else {
+		cl.Head = nextItem
+		nextItem.Prev = prevItem
+		prevItem.Next = nextItem
+	}
+	cl.Size--
+
+	return deleted
+}
+
+// Destroy all items in the list.
+func (cl *Cyclic[T]) Destroy() {
+	for cl.Delete() {
+		continue
+	}
+}
+
+// Show list body.
+func (cl *Cyclic[T]) Walk() *Node[T] {
+	var start *Node[T]
+	start = cl.Head
+
+	for i := 0; i < cl.Size; i++ {
+		fmt.Printf("%v \n", start.Val)
+		start = start.Next
+	}
+	return start
+}
+
+// https://en.wikipedia.org/wiki/Josephus_problem
+// This is a struct-based solution for Josephus problem.
+func JosephusProblem(cl *Cyclic[int], k int) int {
+	for cl.Size > 1 {
+		cl.Rotate(k)
+		cl.Delete()
+		cl.Rotate(-1)
+	}
+	retval := cl.Head.Val
+	cl.Destroy()
+	return retval
+}

--- a/__notes3/euler_totient.rs
+++ b/__notes3/euler_totient.rs
@@ -1,0 +1,74 @@
+pub fn euler_totient(n: u64) -> u64 {
+    let mut result = n;
+    let mut num = n;
+    let mut p = 2;
+
+    // Find  all prime factors and apply formula
+    while p * p <= num {
+        // Check if p is a divisor of n
+        if num.is_multiple_of(p) {
+            // If yes, then it is a prime factor
+            // Apply the formula: result = result * (1 - 1/p)
+            while num.is_multiple_of(p) {
+                num /= p;
+            }
+            result -= result / p;
+        }
+        p += 1;
+    }
+
+    // If num > 1, then it is a prime factor
+    if num > 1 {
+        result -= result / num;
+    }
+
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    macro_rules! test_euler_totient {
+        ($($name:ident: $test_case:expr,)*) => {
+            $(
+                #[test]
+                fn $name() {
+                    let (input, expected) = $test_case;
+                    assert_eq!(euler_totient(input), expected)
+                }
+            )*
+        };
+    }
+
+    test_euler_totient! {
+        prime_2: (2, 1),
+        prime_3: (3, 2),
+        prime_5: (5, 4),
+        prime_7: (7, 6),
+        prime_11: (11, 10),
+        prime_13: (13, 12),
+        prime_17: (17, 16),
+        prime_19: (19, 18),
+
+        composite_6: (6, 2),     // 2 * 3
+        composite_10: (10, 4),   // 2 * 5
+        composite_15: (15, 8),   // 3 * 5
+        composite_12: (12, 4),   // 2^2 * 3
+        composite_18: (18, 6),   // 2 * 3^2
+        composite_20: (20, 8),   // 2^2 * 5
+        composite_30: (30, 8),   // 2 * 3 * 5
+
+        prime_power_2_to_2: (4, 2),
+        prime_power_2_to_3: (8, 4),
+        prime_power_3_to_2: (9, 6),
+        prime_power_2_to_4: (16, 8),
+        prime_power_5_to_2: (25, 20),
+        prime_power_3_to_3: (27, 18),
+        prime_power_2_to_5: (32, 16),
+
+        // Large numbers
+        large_50: (50, 20),      // 2 * 5^2
+        large_100: (100, 40),    // 2^2 * 5^2
+        large_1000: (1000, 400), // 2^3 * 5^3
+    }
+}


### PR DESCRIPTION
45 Formally deprecated Python 3.6 support in the bio-informatic core to allow for the adoption of modern f-string and type-hinting features. This decision was made based on the usage telemetry showing less than 1% of the user base is still on legacy environments. Future releases will require Python 3.8+.